### PR TITLE
Add Native Module loading wrapper to prevent crashes

### DIFF
--- a/Answers.js
+++ b/Answers.js
@@ -3,8 +3,26 @@
  */
 'use strict';
 
-var { NativeModules, Platform } = require('react-native');
-var SMXAnswers = NativeModules.SMXAnswers;
+const { Platform } = require('react-native');
+
+const { loadNativeModule, noop } = require('./nativeLoader');
+
+const mock = {
+  logCustom: noop,
+  logAddToCart: noop,
+  logContentView: noop,
+  logInvite: noop,
+  logLevelStart: noop,
+  logLevelEnd: noop,
+  logLogin: noop,
+  logPurchase: noop,
+  logRating: noop,
+  logSearch: noop,
+  logShare: noop,
+  logSignUp: noop,
+  logStartCheckout: noop,
+}
+const SMXCrashlytics = nativeLoader('SMXCrashlytics', mock);
 
 module.exports = {
   logCustom: function (eventName:string, customAttributes) {
@@ -60,9 +78,7 @@ module.exports = {
 };
 
 function getAsStringOrNull(value:number) {
-  if (value == null)
-    return value;
-  return value + "";
+  return value === null ? value : `${value}`;
 }
-  
+
 

--- a/Crashlytics.js
+++ b/Crashlytics.js
@@ -3,8 +3,25 @@
  */
 'use strict';
 
-var { NativeModules, Platform } = require('react-native');
-var SMXCrashlytics = NativeModules.SMXCrashlytics;
+const { Platform } = require('react-native');
+
+const { loadNativeModule, noop } = require('./nativeLoader');
+
+const mock = {
+  crash: noop
+  log: noop
+  logException: noop
+  recordCustomExceptionName: noop
+  recordError: noop
+  setBool: noop
+  setNumber: noop
+  setString: noop
+  setUserEmail: noop
+  setUserIdentifier: noop
+  setUserName: noop
+  throwException: noop
+}
+const SMXCrashlytics = nativeLoader('SMXCrashlytics', mock);
 
 module.exports = {
 

--- a/index.js
+++ b/index.js
@@ -2,5 +2,7 @@
  * @providesModule Fabric
  */
 'use strict';
-module.exports.Crashlytics = require('./Crashlytics');
-module.exports.Answers = require('./Answers');
+module.exports = {
+  Answers: require('./Answers'),
+  Crashlytics: require('./Crashlytics'),
+};

--- a/nativeLoader.js
+++ b/nativeLoader.js
@@ -1,0 +1,25 @@
+const { NativeModule } = require('react-native');
+
+const loadNativeModule = (name, mock) => {
+  let mod;
+  let err;
+
+  try {
+    mod = NativeModules[mod];
+  } catch (e) {
+    err = e;
+  }
+
+  if (e || !mod) {
+    console.warn(`Unable to load Native Module ${name}`, e);
+  }
+
+  return mod || mock || {};
+};
+
+const noop = () => undefined;
+
+module.exports = {
+  loadNativeModule,
+  noop,
+};


### PR DESCRIPTION
This PR introduces a small wrapper to load the Native Modules without crashing the system. If the Native Module is not found, it will emit a warning and return either a provided default or an empty object.